### PR TITLE
Set initial light gain to lowest

### DIFF
--- a/adafruit_veml7700.py
+++ b/adafruit_veml7700.py
@@ -193,6 +193,8 @@ class VEML7700:
 
     def __init__(self, i2c_bus: I2C, address: int = 0x10) -> None:
         self.i2c_device = i2cdevice.I2CDevice(i2c_bus, address)
+        # Set lowest gain to keep from overflow on init if bright light
+        self.light_gain=self.ALS_GAIN_1_8
         for _ in range(3):
             try:
                 self.light_shutdown = False  # Enable the ambient light sensor

--- a/adafruit_veml7700.py
+++ b/adafruit_veml7700.py
@@ -193,10 +193,11 @@ class VEML7700:
 
     def __init__(self, i2c_bus: I2C, address: int = 0x10) -> None:
         self.i2c_device = i2cdevice.I2CDevice(i2c_bus, address)
-        # Set lowest gain to keep from overflow on init if bright light
-        self.light_gain=self.ALS_GAIN_1_8
         for _ in range(3):
             try:
+                # Set lowest gain to keep from overflow on init if bright light
+                self.light_gain=self.ALS_GAIN_1_8
+                #
                 self.light_shutdown = False  # Enable the ambient light sensor
                 break
             except OSError:


### PR DESCRIPTION
The VEML7700 learn guide says the default gain is 1/8x in the library.  It appears though it is really 1x which is the 0-index in the enumeration; the backing variable for the light_gain value is an int and defaults to 0 which is the 1x.  So while the learn guide could be changed it would seem to make more sense to set the value to the 1/8x in the class constructor.  This is what the vendor recommends in the app note noted in the learn guide so that the sensor is not put into overflow if it has a bright light when initialized.