### PR TITLE
update resolution

### DIFF
--- a/adafruit_veml7700.py
+++ b/adafruit_veml7700.py
@@ -246,7 +246,7 @@ class VEML7700:
     def resolution(self) -> float:
         """Calculate the :meth:`resolution`` necessary to calculate lux. Based on
         integration time and gain settings."""
-        resolution_at_max = 0.0036
+        resolution_at_max = 0.0042
         gain_max = 2
         integration_time_max = 800
 


### PR DESCRIPTION
@ladyada 

Resolves: #32 

their main datasheet link stays updated always pointing to the latest revision. The link on the downloads section of the learn guide is that main always updated link.

I confirmed in the current revision it lists `.0042` as the resolution in a handful of places and doesn't list `.0036` anywhere. 
![image](https://github.com/user-attachments/assets/d52e8e7e-6a7c-46fa-8265-5267f3ac4217)


I did also find an older revision of the datasheet here: https://www.sigmaelectronica.net/wp-content/uploads/2019/10/veml7700-Datasheet.pdf that does show the `.0036` value.  So it seems like they indeed changed that value some time along the way. 


The arduino library is also using `.0036`, I can change it over there if we want to have this change
